### PR TITLE
Adding an option to read an image from folder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,4 +202,5 @@ target_link_libraries(
     ${PROJECT_NAME}_node
     PRIVATE
       ${PROJECT_NAME}
+      stdc++fs
 )

--- a/include/ov2slam.hpp
+++ b/include/ov2slam.hpp
@@ -25,13 +25,12 @@
 */
 #pragma once
 
-
-#include <vector>
-#include <queue>
 #include <mutex>
+#include <queue>
+#include <vector>
 
-#include "slam_params.hpp"
 #include "ros_visualizer.hpp"
+#include "slam_params.hpp"
 
 #include "logger.hpp"
 
@@ -39,11 +38,11 @@
 #include "feature_extractor.hpp"
 #include "feature_tracker.hpp"
 
+#include "estimator.hpp"
 #include "frame.hpp"
 #include "map_manager.hpp"
-#include "visual_front_end.hpp"
 #include "mapper.hpp"
-#include "estimator.hpp"
+#include "visual_front_end.hpp"
 
 class SlamManager {
 
@@ -54,14 +53,14 @@ public:
 
     void run();
 
-    bool getNewImage(cv::Mat &iml, cv::Mat &imr, double &time);
+    bool getNewImage(cv::Mat& iml, cv::Mat& imr, double& time);
 
-    void addNewStereoImages(const double time, cv::Mat &im0, cv::Mat &im1);
-    void addNewMonoImage(const double time, cv::Mat &im0);
+    void addNewStereoImages(const double time, cv::Mat& im0, cv::Mat& im1);
+    void addNewMonoImage(const double time, cv::Mat& im0);
 
     void setupCalibration();
     void setupStereoCalibration();
-    
+
     void reset();
 
     void writeResults();
@@ -69,23 +68,28 @@ public:
     void writeFullTrajectoryLC();
 
     void visualizeAtFrameRate(const double time);
-    void visualizeFrame(const cv::Mat &imleft, const double time);
+    void visualizeFrame(const cv::Mat& imleft, const double time);
     void visualizeVOTraj(const double time);
 
     void visualizeAtKFsRate(const double time);
     void visualizeCovisibleKFs(const double time);
     void visualizeFullKFsTraj(const double time);
-    
+
     void visualizeFinalKFsTraj();
+
+    void setFilenamesTimestamps(std::vector<std::string>& lfilenames, std::vector<std::string>& rfilenames, std::vector<float>& timestamps);
 
     int frame_id_ = -1;
     bool bnew_img_available_ = false;
 
     bool bexit_required_ = false;
     bool bis_on_ = false;
-    
+
     bool bframe_viz_ison_ = false;
     bool bkf_viz_ison_ = false;
+
+    std::vector<std::string> vlfilenames_, vrfilenames_;
+    std::vector<float> vltimestamps_;
 
     std::shared_ptr<SlamParams> pslamstate_;
     std::shared_ptr<RosVisualizer> prosviz_;

--- a/include/slam_params.hpp
+++ b/include/slam_params.hpp
@@ -25,10 +25,9 @@
 */
 #pragma once
 
-
+#include <chrono>
 #include <iostream>
 #include <string>
-#include <chrono>
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
@@ -46,9 +45,9 @@ class SlamParams {
 public:
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-    SlamParams() {}
-    
-    SlamParams(const cv::FileStorage &fsSettings);
+    SlamParams() { }
+
+    SlamParams(const cv::FileStorage& fsSettings);
 
     void reset();
 
@@ -61,7 +60,8 @@ public:
     bool bvision_init_ = false;
     bool breset_req_ = false;
     bool bforce_realtime_ = false;
-
+    bool bread_images_from_folder_ = false;
+    float fps;
     //=====================================================
     // Variables relative to the setup used for the SLAM
     //=====================================================
@@ -93,7 +93,7 @@ public:
     int lckfid_ = -1;
 
     float finit_parallax_;
-    
+
     bool bdo_stereo_rect_;
     double alpha_;
     float fepi_th_;
@@ -101,7 +101,7 @@ public:
     // Keypoints Extraction
     bool use_fast_, use_shi_tomasi_, use_brief_;
     bool use_singlescale_detector_;
-    
+
     int nfast_th_;
     int nbmaxkps_, nmaxdist_;
     double dmaxquality_;
@@ -124,7 +124,7 @@ public:
 
     // Matching th.
     bool bdo_track_localmap_;
-    
+
     float fmax_desc_dist_;
     float fmax_proj_pxdist_;
 

--- a/parameters_files/accurate/image_sequence/param.yaml
+++ b/parameters_files/accurate/image_sequence/param.yaml
@@ -1,0 +1,157 @@
+%YAML 1.0
+---
+
+#--------------------------------------------------------------------------------------------
+# Camera Parameters. Adjust them!
+#--------------------------------------------------------------------------------------------
+
+# Set to 1 to read images from folder
+read_images_from_folder: 1
+fps: 30.0 # Frames per second (only needed if read_images_from_folder is set to 1)
+
+Camera.topic_left: PATH_TO_FOLDER
+Camera.topic_right: PATH_TO_FOLDER
+
+Camera.model_left: pinhole
+Camera.model_right: pinhole
+
+Camera.left_nwidth: 1241
+Camera.left_nheight: 376
+
+Camera.right_nwidth: 1241
+Camera.right_nheight: 376
+
+# Camera calibration and distortion parameters (OpenCV) 
+Camera.fxl: 718.856
+Camera.fyl: 718.856
+Camera.cxl: 607.1928
+Camera.cyl: 185.2157
+
+Camera.k1l: 0.
+Camera.k2l: 0.
+Camera.p1l: 0.
+Camera.p2l: 0.
+
+Camera.fxr: 718.856
+Camera.fyr: 718.856
+Camera.cxr: 607.1928
+Camera.cyr: 185.2157
+
+Camera.k1r: 0.
+Camera.k2r: 0.
+Camera.p1r: 0.
+Camera.p2r: 0.
+
+
+# Camera Extrinsic parameters T_b_ci ( v_b = T_b_ci * v_ci )
+body_T_cam0: !!opencv-matrix
+   rows: 4
+   cols: 4
+   dt: d
+   data: [1., 0., 0., 0.,
+          0., 1., 0., 0.,
+          0., 0., 1., 0.,
+           0., 0., 0., 1.]
+
+body_T_cam1: !!opencv-matrix
+   rows: 4
+   cols: 4
+   dt: d
+   data: [1., 0., 0., 0.537165718864418,
+          0., 1., 0., 0.,
+          0., 0., 1., 0.,
+           0., 0., 0., 1.]
+
+#--------------------------------------------------------------------------------------------
+# SLAM Parameters. Adjust them!
+#--------------------------------------------------------------------------------------------
+debug: 0
+log_timings: 0
+
+mono: 0
+stereo: 1
+
+force_realtime: 0
+
+# Estimator Mode
+slam_mode: 1
+
+
+# Loop Closing mode
+buse_loop_closer: 1
+
+# Stereo rectify or not
+bdo_stereo_rect: 1
+alpha: 0.
+
+# Init / KF px th.
+finit_parallax: 20.
+
+
+# Features Extractor
+use_shi_tomasi: 0
+use_fast: 0
+use_brief: 1
+use_singlescale_detector: 1
+
+# Min dist between kps (define the number of kps)
+nmaxdist: 35
+
+# Features quality th.
+nfast_th: 10
+dmaxquality: 0.001 # used for gftt or singlescale
+
+# Pre-processing
+use_clahe: 1
+fclahe_val: 2
+
+# KLT related settings.
+do_klt: 1
+klt_use_prior: 1
+btrack_keyframetoframe: 0
+nklt_win_size: 9
+nklt_pyr_lvl: 3
+
+# Opencv Default: 30 iters. + 0.01 prec.
+nmax_iter: 30
+fmax_px_precision: 0.01
+
+fmax_fbklt_dist: 0.5
+nklt_err: 30.
+
+# Matching th.
+bdo_track_localmap: 1
+
+fmax_desc_dist: 0.2 #0.35 # Ratio from desc size (for binary desc.) 
+fmax_proj_pxdist: 2.
+
+# Randomize RANSAC?
+doepipolar: 1
+dop3p : 0
+bdo_random: 1
+nransac_iter: 100
+fransac_err: 3.
+
+# Reproj err th.
+fmax_reproj_err: 3.
+buse_inv_depth: 1
+
+# Ceres related parameters
+robust_mono_th: 5.9915 # (20% : 3.2189 / 10% :  4.6052 / 5% : 5.9915 / 2%: 7.8240 / 1%: 9.2103)  
+
+use_sparse_schur: 1
+use_dogleg: 0
+use_subspace_dogleg: 0
+use_nonmonotic_step: 0
+
+# Estimator parameters
+apply_l2_after_robust: 1
+
+nmin_covscore: 25 # Min co-obs for optimizing in SLAM mode BA
+
+
+# Map Filtering
+fkf_filtering_ratio: 0.95
+
+# Final Pass
+do_full_ba: 0

--- a/src/ov2slam.cpp
+++ b/src/ov2slam.cpp
@@ -24,11 +24,10 @@
 *             Martial Sanfourche <first.last at onera dot fr>      (ONERA, DTIS - IVA)
 */
 
-#include <thread>
 #include <opencv2/highgui.hpp>
+#include <thread>
 
 #include "ov2slam.hpp"
-
 
 SlamManager::SlamManager(std::shared_ptr<SlamParams> pstate, std::shared_ptr<RosVisualizer> pviz)
     : pslamstate_(pstate)
@@ -36,32 +35,32 @@ SlamManager::SlamManager(std::shared_ptr<SlamParams> pstate, std::shared_ptr<Ros
 {
     std::cout << "\n SLAM Manager is being created...\n";
 
-    #ifdef OPENCV_CONTRIB
-        std::cout << "\n OPENCV CONTRIB FOUND!  BRIEF DESCRIPTOR WILL BE USED!\n";
-    #else
-        std::cout << "\n OPENCV CONTRIB NOT FOUND!  ORB DESCRIPTOR WILL BE USED!\n";
-    #endif
+#ifdef OPENCV_CONTRIB
+    std::cout << "\n OPENCV CONTRIB FOUND!  BRIEF DESCRIPTOR WILL BE USED!\n";
+#else
+    std::cout << "\n OPENCV CONTRIB NOT FOUND!  ORB DESCRIPTOR WILL BE USED!\n";
+#endif
 
-    #ifdef USE_OPENGV
-        std::cout << "\n OPENGV FOUND!  OPENGV MVG FUNCTIONS WILL BE USED!\n";
-    #else
-        std::cout << "\n OPENGV NOT FOUND!  OPENCV MVG FUNCTIONS WILL BE USED!\n";
-    #endif
+#ifdef USE_OPENGV
+    std::cout << "\n OPENGV FOUND!  OPENGV MVG FUNCTIONS WILL BE USED!\n";
+#else
+    std::cout << "\n OPENGV NOT FOUND!  OPENCV MVG FUNCTIONS WILL BE USED!\n";
+#endif
 
     // We first setup the calibration to init everything related
     // to the configuration of the current run
     std::cout << "\n SetupCalibration()\n";
     setupCalibration();
 
-    if( pslamstate_->stereo_ && pslamstate_->bdo_stereo_rect_ ) {
+    if (pslamstate_->stereo_ && pslamstate_->bdo_stereo_rect_) {
         std::cout << "\n SetupStereoCalibration()\n";
         setupStereoCalibration();
     }
 
-    if( pslamstate_->mono_ ) {
-        pcurframe_.reset( new Frame(pcalib_model_left_, pslamstate_->nmaxdist_) );
-    } else if( pslamstate_->stereo_ ) {
-        pcurframe_.reset( new Frame(pcalib_model_left_, pcalib_model_right_, pslamstate_->nmaxdist_) );
+    if (pslamstate_->mono_) {
+        pcurframe_.reset(new Frame(pcalib_model_left_, pslamstate_->nmaxdist_));
+    } else if (pslamstate_->stereo_) {
+        pcurframe_.reset(new Frame(pcalib_model_left_, pcalib_model_right_, pslamstate_->nmaxdist_));
     } else {
         std::cerr << "\n\n=====================================================\n\n";
         std::cerr << "\t\t YOU MUST CHOOSE BETWEEN MONO / STEREO (and soon RGBD)\n";
@@ -71,34 +70,27 @@ SlamManager::SlamManager(std::shared_ptr<SlamParams> pstate, std::shared_ptr<Ros
     // Create all objects to be used within OV²SLAM
     // =============================================
     int tilesize = 50;
-    cv::Size clahe_tiles(pcalib_model_left_->img_w_ / tilesize
-                        , pcalib_model_left_->img_h_ / tilesize);
-                        
+    cv::Size clahe_tiles(pcalib_model_left_->img_w_ / tilesize, pcalib_model_left_->img_h_ / tilesize);
+
     cv::Ptr<cv::CLAHE> pclahe = cv::createCLAHE(pslamstate_->fclahe_val_, clahe_tiles);
 
-    pfeatextract_.reset( new FeatureExtractor(
-                                pslamstate_->nbmaxkps_, pslamstate_->nmaxdist_, 
-                                pslamstate_->dmaxquality_, pslamstate_->nfast_th_
-                            ) 
-                        );
+    pfeatextract_.reset(new FeatureExtractor(
+        pslamstate_->nbmaxkps_, pslamstate_->nmaxdist_,
+        pslamstate_->dmaxquality_, pslamstate_->nfast_th_));
 
-    ptracker_.reset( new FeatureTracker(pslamstate_->nmax_iter_, 
-                            pslamstate_->fmax_px_precision_, pclahe
-                        )
-                    );
+    ptracker_.reset(new FeatureTracker(pslamstate_->nmax_iter_,
+        pslamstate_->fmax_px_precision_, pclahe));
 
     // Map Manager will handle Keyframes / MapPoints
-    pmap_.reset( new MapManager(pslamstate_, pcurframe_, pfeatextract_, ptracker_) );
+    pmap_.reset(new MapManager(pslamstate_, pcurframe_, pfeatextract_, ptracker_));
 
-    // Visual Front-End processes every incoming frames 
-    pvisualfrontend_.reset( new VisualFrontEnd(pslamstate_, pcurframe_, 
-                                    pmap_, ptracker_
-                                )
-                            );
+    // Visual Front-End processes every incoming frames
+    pvisualfrontend_.reset(new VisualFrontEnd(pslamstate_, pcurframe_,
+        pmap_, ptracker_));
 
     // Mapper thread handles Keyframes' processing
     // (i.e. triangulation, local map tracking, BA, LC)
-    pmapper_.reset( new Mapper(pslamstate_, pmap_, pcurframe_) );
+    pmapper_.reset(new Mapper(pslamstate_, pmap_, pcurframe_));
 }
 
 void SlamManager::run()
@@ -114,18 +106,17 @@ void SlamManager::run()
     double last_img_time = -1.; // Last received image time
 
     // Main SLAM loop
-    while( !bexit_required_ ) {
+    while (!bexit_required_) {
 
         // 0. Get New Images
         // =============================================
-        if( getNewImage(img_left, img_right, time) )
-        {
+        if (getNewImage(img_left, img_right, time)) {
             // Update current frame
             frame_id_++;
             pcurframe_->updateFrame(frame_id_, time);
 
             // Update cam delay for automatic exit
-            if( frame_id_ > 0 ) {
+            if (frame_id_ > 0) {
                 cam_delay = ros::Time::now().toSec() - last_img_time;
                 last_img_time += cam_delay;
             } else {
@@ -133,12 +124,12 @@ void SlamManager::run()
             }
 
             // Display info on current frame state
-            if( pslamstate_->debug_ )
+            if (pslamstate_->debug_)
                 pcurframe_->displayFrameInfo();
 
             // 1. Send images to the FrontEnd
             // =============================================
-            if( pslamstate_->debug_ )
+            if (pslamstate_->debug_)
                 std::cout << "\n \t >>> [SLAM Node] New image send to Front-End\n";
 
             bool is_kf_req = pvisualfrontend_->visualTracking(img_left, time);
@@ -146,64 +137,66 @@ void SlamManager::run()
             // Save current pose
             Logger::addSE3Pose(time, pcurframe_->getTwc(), is_kf_req);
 
-            if( pslamstate_->breset_req_ ) {
+            if (pslamstate_->breset_req_) {
                 reset();
                 continue;
             }
 
             // 2. Create new KF if req. / Send new KF to Mapper
             // ================================================
-            if( is_kf_req ) 
-            {
-                if( pslamstate_->debug_ )
+            if (is_kf_req) {
+                if (pslamstate_->debug_)
                     std::cout << "\n \t >>> [SLAM Node] New Keyframe send to Back-End\n";
 
-                if( pslamstate_->stereo_ ) 
-                {
+                if (pslamstate_->stereo_) {
                     Keyframe kf(
-                        pcurframe_->kfid_, 
+                        pcurframe_->kfid_,
                         img_left,
                         img_right,
-                        pvisualfrontend_->cur_pyr_
-                        );
+                        pvisualfrontend_->cur_pyr_);
 
                     pmapper_->addNewKf(kf);
-                } 
-                else if( pslamstate_->mono_ ) 
-                {
+                } else if (pslamstate_->mono_) {
                     Keyframe kf(pcurframe_->kfid_, img_left);
                     pmapper_->addNewKf(kf);
                 }
 
-                if( !bkf_viz_ison_ ) {
+                if (!bkf_viz_ison_) {
                     std::thread kf_viz_thread(&SlamManager::visualizeAtKFsRate, this, time);
                     kf_viz_thread.detach();
-                }    
+                }
             }
 
-            if( pslamstate_->debug_ || pslamstate_->log_timings_ )
+            if (pslamstate_->debug_ || pslamstate_->log_timings_)
                 std::cout << Profiler::getInstance().displayTimeLogs() << std::endl;
 
             // Frame rate visualization (limit the visualization processing)
-            if( !bframe_viz_ison_ ) {
+            if (!bframe_viz_ison_) {
                 std::thread viz_thread(&SlamManager::visualizeAtFrameRate, this, time);
                 viz_thread.detach();
             }
-        } 
+        }
+
         else {
+            bool c1, c2, c3;
 
             // 3. Check if we are done with a sequence!
             // ========================================
-            bool c1 = cam_delay > 0;
-            bool c2 = ( ros::Time::now().toSec() - last_img_time ) > 100. * cam_delay;
-            bool c3 = !bnew_img_available_;
+            if (pslamstate_->bread_images_from_folder_) {
+                c1 = true;
+                c2 = true;
+                c3 = true;
+            } else {
+                c1 = cam_delay > 0;
+                c2 = (ros::Time::now().toSec() - last_img_time) > 100. * cam_delay;
+                c3 = !bnew_img_available_;
+            }
 
-            if( c1 && c2 && c3 )
-            {
+            if (c1 && c2 && c3) {
                 bexit_required_ = true;
 
-                // Warn threads to stop and then save the results only in this case of 
-                // automatic stop because end of sequence reached 
+                // Warn threads to stop and then save the results only in this case of
+                // automatic stop because end of sequence reached
                 // (avoid wasting time when forcing stop by CTRL+C)
                 pmapper_->bexit_required_ = true;
 
@@ -211,8 +204,7 @@ void SlamManager::run()
 
                 // Notify exit to ROS
                 ros::requestShutdown();
-            }
-            else {
+            } else {
                 std::chrono::milliseconds dura(1);
                 std::this_thread::sleep_for(dura);
             }
@@ -224,7 +216,7 @@ void SlamManager::run()
     bis_on_ = false;
 }
 
-void SlamManager::addNewMonoImage(const double time, cv::Mat &im0)
+void SlamManager::addNewMonoImage(const double time, cv::Mat& im0)
 {
     std::lock_guard<std::mutex> lock(img_mutex_);
     qimg_left_.push(im0);
@@ -233,9 +225,9 @@ void SlamManager::addNewMonoImage(const double time, cv::Mat &im0)
     bnew_img_available_ = true;
 }
 
-void SlamManager::addNewStereoImages(const double time, cv::Mat &im0, cv::Mat &im1) 
+void SlamManager::addNewStereoImages(const double time, cv::Mat& im0, cv::Mat& im1)
 {
-    if( pslamstate_->bdo_stereo_rect_ ) {
+    if (pslamstate_->bdo_stereo_rect_) {
         pcalib_model_left_->rectifyImage(im0, im0);
         pcalib_model_right_->rectifyImage(im1, im1);
     }
@@ -248,11 +240,24 @@ void SlamManager::addNewStereoImages(const double time, cv::Mat &im0, cv::Mat &i
     bnew_img_available_ = true;
 }
 
-bool SlamManager::getNewImage(cv::Mat &iml, cv::Mat &imr, double &time)
+bool SlamManager::getNewImage(cv::Mat& iml, cv::Mat& imr, double& time)
 {
     std::lock_guard<std::mutex> lock(img_mutex_);
 
-    if( !bnew_img_available_ ) {
+    if (pslamstate_->bread_images_from_folder_) {
+        if (size_t(frame_id_ + 1) == vlfilenames_.size())
+            return false;
+
+        iml = cv::imread(vlfilenames_[frame_id_ + 1], cv::IMREAD_GRAYSCALE);
+        time = vltimestamps_[frame_id_ + 1];
+
+        if (pslamstate_->stereo_) {
+            imr = cv::imread(vrfilenames_[frame_id_ + 1], cv::IMREAD_GRAYSCALE);
+        }
+        return true;
+    }
+
+    if (!bnew_img_available_) {
         return false;
     }
 
@@ -266,23 +271,23 @@ bool SlamManager::getNewImage(cv::Mat &iml, cv::Mat &imr, double &time)
 
         time = qimg_time_.front();
         qimg_time_.pop();
-        
-        if( pslamstate_->stereo_ ) {
+
+        if (pslamstate_->stereo_) {
             imr = qimg_right_.front();
             qimg_right_.pop();
         }
 
-        if( !pslamstate_->bforce_realtime_ )
+        if (!pslamstate_->bforce_realtime_)
             break;
 
-    } while( !qimg_left_.empty() );
+    } while (!qimg_left_.empty());
 
-    if( k > 1 ) {    
-        if( pslamstate_->debug_ )
-            std::cout << "\n SLAM is late!  Skipped " << k-1 << " frames...\n";
+    if (k > 1) {
+        if (pslamstate_->debug_)
+            std::cout << "\n SLAM is late!  Skipped " << k - 1 << " frames...\n";
     }
-    
-    if( qimg_left_.empty() ) {
+
+    if (qimg_left_.empty()) {
         bnew_img_available_ = false;
     }
 
@@ -291,33 +296,28 @@ bool SlamManager::getNewImage(cv::Mat &iml, cv::Mat &imr, double &time)
 
 void SlamManager::setupCalibration()
 {
-    pcalib_model_left_.reset( 
-                new CameraCalibration(
-                        pslamstate_->cam_left_model_, 
-                        pslamstate_->fxl_, pslamstate_->fyl_, 
-                        pslamstate_->cxl_, pslamstate_->cyl_,
-                        pslamstate_->k1l_, pslamstate_->k2l_, 
-                        pslamstate_->p1l_, pslamstate_->p2l_,
-                        pslamstate_->img_left_w_, 
-                        pslamstate_->img_left_h_
-                        ) 
-                    );
+    pcalib_model_left_.reset(
+        new CameraCalibration(
+            pslamstate_->cam_left_model_,
+            pslamstate_->fxl_, pslamstate_->fyl_,
+            pslamstate_->cxl_, pslamstate_->cyl_,
+            pslamstate_->k1l_, pslamstate_->k2l_,
+            pslamstate_->p1l_, pslamstate_->p2l_,
+            pslamstate_->img_left_w_,
+            pslamstate_->img_left_h_));
 
-    if( pslamstate_->stereo_ ) 
-    {
-        pcalib_model_right_.reset( 
-                    new CameraCalibration(
-                            pslamstate_->cam_right_model_, 
-                            pslamstate_->fxr_, pslamstate_->fyr_, 
-                            pslamstate_->cxr_, pslamstate_->cyr_,
-                            pslamstate_->k1r_, pslamstate_->k2r_, 
-                            pslamstate_->p1r_, pslamstate_->p2r_,
-                            pslamstate_->img_right_w_, 
-                            pslamstate_->img_right_h_
-                            ) 
-                        );
-        
-        // TODO: Change this and directly add the extrinsic parameters within the 
+    if (pslamstate_->stereo_) {
+        pcalib_model_right_.reset(
+            new CameraCalibration(
+                pslamstate_->cam_right_model_,
+                pslamstate_->fxr_, pslamstate_->fyr_,
+                pslamstate_->cxr_, pslamstate_->cyr_,
+                pslamstate_->k1r_, pslamstate_->k2r_,
+                pslamstate_->p1r_, pslamstate_->p2r_,
+                pslamstate_->img_right_w_,
+                pslamstate_->img_right_h_));
+
+        // TODO: Change this and directly add the extrinsic parameters within the
         // constructor (maybe set default parameters on extrinsic with identity / zero)
         pcalib_model_right_->setupExtrinsic(pslamstate_->T_left_right_);
     }
@@ -330,38 +330,42 @@ void SlamManager::setupStereoCalibration()
 
     cv::Rect rectleft, rectright;
 
-    if( cv::countNonZero(pcalib_model_left_->Dcv_) == 0 && 
-        cv::countNonZero(pcalib_model_right_->Dcv_) == 0 &&
-        pcalib_model_right_->Tc0ci_.rotationMatrix().isIdentity(1.e-5) )
-    {
+    if (cv::countNonZero(pcalib_model_left_->Dcv_) == 0 && cv::countNonZero(pcalib_model_right_->Dcv_) == 0 && pcalib_model_right_->Tc0ci_.rotationMatrix().isIdentity(1.e-5)) {
         std::cout << "\n No distorsion and R_left_right = I3x3 / NO rectif to apply!";
         return;
     }
 
     cv::stereoRectify(
-            pcalib_model_left_->Kcv_, pcalib_model_left_->Dcv_,
-            pcalib_model_right_->Kcv_, pcalib_model_right_->Dcv_,
-            pcalib_model_left_->img_size_, 
-            pcalib_model_right_->Rcv_cic0_, 
-            pcalib_model_right_->tcv_cic0_,
-            Rl, Rr, Pl, Pr, Q, cv::CALIB_ZERO_DISPARITY, pslamstate_->alpha_,
-            pcalib_model_left_->img_size_, 
-            &rectleft, &rectright
-            );
+        pcalib_model_left_->Kcv_, pcalib_model_left_->Dcv_,
+        pcalib_model_right_->Kcv_, pcalib_model_right_->Dcv_,
+        pcalib_model_left_->img_size_,
+        pcalib_model_right_->Rcv_cic0_,
+        pcalib_model_right_->tcv_cic0_,
+        Rl, Rr, Pl, Pr, Q, cv::CALIB_ZERO_DISPARITY, pslamstate_->alpha_,
+        pcalib_model_left_->img_size_,
+        &rectleft, &rectright);
 
     std::cout << "\n Alpha : " << pslamstate_->alpha_;
 
-    std::cout << "\n Kl : \n" << pcalib_model_left_->Kcv_;
-    std::cout << "\n Kr : \n" << pcalib_model_right_->Kcv_;
+    std::cout << "\n Kl : \n"
+              << pcalib_model_left_->Kcv_;
+    std::cout << "\n Kr : \n"
+              << pcalib_model_right_->Kcv_;
 
-    std::cout << "\n Dl : \n" << pcalib_model_left_->Dcv_;
-    std::cout << "\n Dr : \n" << pcalib_model_right_->Dcv_;
+    std::cout << "\n Dl : \n"
+              << pcalib_model_left_->Dcv_;
+    std::cout << "\n Dr : \n"
+              << pcalib_model_right_->Dcv_;
 
-    std::cout << "\n Rl : \n" << Rl;
-    std::cout << "\n Rr : \n" << Rr;
-    
-    std::cout << "\n Pl : \n" << Pl;
-    std::cout << "\n Pr : \n" << Pr;
+    std::cout << "\n Rl : \n"
+              << Rl;
+    std::cout << "\n Rr : \n"
+              << Rr;
+
+    std::cout << "\n Pl : \n"
+              << Pl;
+    std::cout << "\n Pr : \n"
+              << Pr;
 
     // % OpenCV can handle left-right or up-down camera arrangements
     // isVerticalStereo = abs(RCT.P2(2,4)) > abs(RCT.P2(1,4));
@@ -399,31 +403,30 @@ void SlamManager::reset()
     frame_id_ = -1;
 
     std::lock_guard<std::mutex> lock(img_mutex_);
-    
-    qimg_left_ = std::queue<cv::Mat>(); 
+
+    qimg_left_ = std::queue<cv::Mat>();
     qimg_right_ = std::queue<cv::Mat>();
     qimg_time_ = std::queue<double>();
 
     bnew_img_available_ = false;
-    
+
     std::cout << "\n=======================================\n";
     std::cout << "\t RESET APPLIED!";
     std::cout << "\n=======================================\n";
 }
 
-
 // ==========================
 //   Visualization functions
 // ==========================
 
-void SlamManager::visualizeAtFrameRate(const double time) 
+void SlamManager::visualizeAtFrameRate(const double time)
 {
     bframe_viz_ison_ = true;
-    
+
     visualizeFrame(pvisualfrontend_->cur_img_, time);
     visualizeVOTraj(time);
     prosviz_->pubPointCloud(pmap_->pcloud_, time);
-    
+
     bframe_viz_ison_ = false;
 }
 
@@ -437,10 +440,9 @@ void SlamManager::visualizeAtKFsRate(const double time)
     bkf_viz_ison_ = false;
 }
 
-
-void SlamManager::visualizeFrame(const cv::Mat &imleft, const double time)
+void SlamManager::visualizeFrame(const cv::Mat& imleft, const double time)
 {
-    if( prosviz_->pub_image_track_.getNumSubscribers() == 0 ) {
+    if (prosviz_->pub_image_track_.getNumSubscribers() == 0) {
         return;
     }
 
@@ -448,19 +450,19 @@ void SlamManager::visualizeFrame(const cv::Mat &imleft, const double time)
     cv::Mat img_2_pub;
     cv::cvtColor(imleft, img_2_pub, CV_GRAY2RGB);
 
-    for( const auto &kp : pcurframe_->getKeypoints() ) {
+    for (const auto& kp : pcurframe_->getKeypoints()) {
         cv::Scalar col;
 
-        if(kp.is_retracked_) {
-            if(kp.is3d_) {
-                col = cv::Scalar(0,255,0);
+        if (kp.is_retracked_) {
+            if (kp.is3d_) {
+                col = cv::Scalar(0, 255, 0);
             } else {
                 col = cv::Scalar(235, 235, 52);
-            } 
-        } else if(kp.is3d_) {
-            col = cv::Scalar(255,0,0);
+            }
+        } else if (kp.is3d_) {
+            col = cv::Scalar(255, 0, 0);
         } else {
-            col = cv::Scalar(0,0,255);
+            col = cv::Scalar(0, 0, 255);
         }
 
         cv::circle(img_2_pub, kp.px_, 4, col, -1);
@@ -469,22 +471,20 @@ void SlamManager::visualizeFrame(const cv::Mat &imleft, const double time)
     prosviz_->pubTrackImage(img_2_pub, time);
 }
 
-
 void SlamManager::visualizeVOTraj(const double time)
 {
     prosviz_->pubVO(pcurframe_->getTwc(), time);
 }
 
-
 void SlamManager::visualizeCovisibleKFs(const double time)
 {
-    if( prosviz_->pub_kfs_pose_.getNumSubscribers() == 0 ) {
+    if (prosviz_->pub_kfs_pose_.getNumSubscribers() == 0) {
         return;
     }
 
-    for( const auto &covkf : pcurframe_->getCovisibleKfMap() ) {
+    for (const auto& covkf : pcurframe_->getCovisibleKfMap()) {
         auto pkf = pmap_->getKeyframe(covkf.first);
-        if( pkf != nullptr ) {
+        if (pkf != nullptr) {
             prosviz_->addVisualKF(pkf->getTwc());
         }
     }
@@ -492,33 +492,31 @@ void SlamManager::visualizeCovisibleKFs(const double time)
     prosviz_->pubVisualKFs(time);
 }
 
-
 void SlamManager::visualizeFullKFsTraj(const double time)
 {
-    if( prosviz_->pub_kfs_traj_.getNumSubscribers() == 0 ) {
-            return;
+    if (prosviz_->pub_kfs_traj_.getNumSubscribers() == 0) {
+        return;
     }
 
     prosviz_->clearKFsTraj();
-    for( int i = 0 ; i <= pcurframe_->kfid_ ; i++ ) {
+    for (int i = 0; i <= pcurframe_->kfid_; i++) {
         auto pkf = pmap_->getKeyframe(i);
-        if( pkf != nullptr ) {
+        if (pkf != nullptr) {
             prosviz_->addKFsTraj(pkf->getTwc());
         }
     }
     prosviz_->pubKFsTraj(time);
 }
 
-
 void SlamManager::visualizeFinalKFsTraj()
 {
-    if( prosviz_->pub_final_kfs_traj_.getNumSubscribers() == 0 ) {
+    if (prosviz_->pub_final_kfs_traj_.getNumSubscribers() == 0) {
         return;
     }
 
-    for( int i = 0 ; i <= pcurframe_->kfid_ ; i++ ) {
+    for (int i = 0; i <= pcurframe_->kfid_; i++) {
         auto pkf = pmap_->getKeyframe(i);
-        if( pkf != nullptr ) {
+        if (pkf != nullptr) {
             prosviz_->pubFinalKFsTraj(pkf->getTwc(), pkf->img_time_);
         }
     }
@@ -528,42 +526,39 @@ void SlamManager::visualizeFinalKFsTraj()
 // Write Results functions
 // ==========================
 
-
 void SlamManager::writeResults()
 {
     // Make sure that nothing is running in the background
-    while( pslamstate_->blocalba_is_on_ || pslamstate_->blc_is_on_ ) {
+    while (pslamstate_->blocalba_is_on_ || pslamstate_->blc_is_on_) {
         std::chrono::seconds dura(1);
         std::this_thread::sleep_for(dura);
     }
-    
+
     visualizeFullKFsTraj(pcurframe_->img_time_);
 
     // Write Trajectories files
     Logger::writeTrajectory("ov2slam_traj.txt");
     Logger::writeTrajectoryKITTI("ov2slam_traj_kitti.txt");
 
-    for( const auto & kfid_pkf : pmap_->map_pkfs_ )
-    {
+    for (const auto& kfid_pkf : pmap_->map_pkfs_) {
         auto pkf = kfid_pkf.second;
-        if( pkf != nullptr ) {
+        if (pkf != nullptr) {
             Logger::addKfSE3Pose(pkf->img_time_, pkf->getTwc());
         }
     }
     Logger::writeKfsTrajectory("ov2slam_kfs_traj.txt");
 
     // Apply full BA on KFs + 3D MPs if required + save
-    if( pslamstate_->do_full_ba_ ) 
-    {
+    if (pslamstate_->do_full_ba_) {
         std::lock_guard<std::mutex> lock(pmap_->map_mutex_);
         pmapper_->runFullBA();
 
         prosviz_->pubPointCloud(pmap_->pcloud_, ros::Time::now().toSec());
         visualizeFinalKFsTraj();
 
-        for( const auto & kfid_pkf : pmap_->map_pkfs_ ) {
+        for (const auto& kfid_pkf : pmap_->map_pkfs_) {
             auto pkf = kfid_pkf.second;
-            if( pkf != nullptr ) {
+            if (pkf != nullptr) {
                 Logger::addKfSE3Pose(pkf->img_time_, pkf->getTwc());
             }
         }
@@ -572,12 +567,10 @@ void SlamManager::writeResults()
     }
 
     // Write full trajectories taking into account LC
-    if( pslamstate_->buse_loop_closer_ )
-    {
+    if (pslamstate_->buse_loop_closer_) {
         writeFullTrajectoryLC();
     }
 }
-
 
 void SlamManager::writeFullTrajectoryLC()
 {
@@ -603,22 +596,19 @@ void SlamManager::writeFullTrajectoryLC()
 
     float fid = 0.;
 
-    for( auto & fr : Logger::vframepose_ )
-    {
-        if( !fr.iskf_ || (fr.iskf_ && !pmap_->map_pkfs_.count(kfid)) ) 
-        {
+    for (auto& fr : Logger::vframepose_) {
+        if (!fr.iskf_ || (fr.iskf_ && !pmap_->map_pkfs_.count(kfid))) {
             // Get frame's pose from relative pose w.r.t. prev frame
             Eigen::Map<Eigen::Vector3d> t(fr.tprev_cur_);
             Eigen::Map<Eigen::Quaterniond> q(fr.qprev_cur_);
 
-            vTpc.push_back(Sophus::SE3d(q,t));
+            vTpc.push_back(Sophus::SE3d(q, t));
 
-            Sophus::SE3d Tprevcur(q,t);
+            Sophus::SE3d Tprevcur(q, t);
 
             Twc = Twc * Tprevcur;
 
             viskf.push_back(false);
-
         } else {
 
             // Get keyframe's pose from map manager
@@ -634,7 +624,7 @@ void SlamManager::writeFullTrajectoryLC()
 
             Eigen::Map<Eigen::Vector3d> t(fr.tprev_cur_);
             Eigen::Map<Eigen::Quaterniond> q(fr.qprev_cur_);
-            vTpc.push_back(Sophus::SE3d(q,t));
+            vTpc.push_back(Sophus::SE3d(q, t));
         }
 
         vTwc.push_back(Twc);
@@ -643,7 +633,7 @@ void SlamManager::writeFullTrajectoryLC()
         Eigen::Quaterniond qwc = Twc.unit_quaternion();
 
         f << std::setprecision(9) << fid << " " << twc.x() << " " << twc.y() << " " << twc.z()
-            << " " << qwc.x() << " " << qwc.y() << " " << qwc.z() << " " << qwc.w() << std::endl;
+          << " " << qwc.x() << " " << qwc.y() << " " << qwc.z() << " " << qwc.w() << std::endl;
 
         f.flush();
 
@@ -653,7 +643,14 @@ void SlamManager::writeFullTrajectoryLC()
     f.close();
 
     std::cout << "\nFull Trajectory w. LC file written!\n";
-    
+
     // Apply full pose graph for optimal full trajectory w. LC
     pmapper_->pestimator_->poptimizer_->fullPoseGraph(vTwc, vTpc, viskf);
+}
+
+void SlamManager::setFilenamesTimestamps(std::vector<std::string>& lfilenames, std::vector<std::string>& rfilenames, std::vector<float>& timestamps)
+{
+    vlfilenames_ = lfilenames;
+    vrfilenames_ = rfilenames;
+    vltimestamps_ = timestamps;
 }

--- a/src/ov2slam_node.cpp
+++ b/src/ov2slam_node.cpp
@@ -24,22 +24,23 @@
 *             Martial Sanfourche <first.last at onera dot fr>      (ONERA, DTIS - IVA)
 */
 
+#include <experimental/filesystem>
 #include <iostream>
-#include <string>
-#include <thread>
 #include <mutex>
 #include <queue>
+#include <string>
+#include <thread>
 
-#include <ros/ros.h>
 #include <ros/console.h>
+#include <ros/ros.h>
 
 #include <image_transport/image_transport.h>
 #include <image_transport/subscriber_filter.h>
 
 #include <sensor_msgs/CameraInfo.h>
 #include <sensor_msgs/Image.h>
-#include <sensor_msgs/image_encodings.h>
 #include <sensor_msgs/Imu.h>
+#include <sensor_msgs/image_encodings.h>
 
 #include <cv_bridge/cv_bridge.h>
 #include <opencv2/core.hpp>
@@ -47,33 +48,34 @@
 #include "ov2slam.hpp"
 #include "slam_params.hpp"
 
-
 class SensorsGrabber {
 
 public:
-    SensorsGrabber(SlamManager *slam): pslam_(slam) {
+    SensorsGrabber(SlamManager* slam)
+        : pslam_(slam)
+    {
         std::cout << "\nSensors Grabber is created...\n";
     }
 
-    void subLeftImage(const sensor_msgs::ImageConstPtr &image) {
+    void subLeftImage(const sensor_msgs::ImageConstPtr& image)
+    {
         std::lock_guard<std::mutex> lock(img_mutex);
         img0_buf.push(image);
     }
 
-    void subRightImage(const sensor_msgs::ImageConstPtr &image) {
+    void subRightImage(const sensor_msgs::ImageConstPtr& image)
+    {
         std::lock_guard<std::mutex> lock(img_mutex);
         img1_buf.push(image);
     }
 
-    cv::Mat getGrayImageFromMsg(const sensor_msgs::ImageConstPtr &img_msg)
+    cv::Mat getGrayImageFromMsg(const sensor_msgs::ImageConstPtr& img_msg)
     {
         // Get and prepare images
         cv_bridge::CvImageConstPtr ptr;
-        try {    
+        try {
             ptr = cv_bridge::toCvCopy(img_msg, sensor_msgs::image_encodings::MONO8);
-        } 
-        catch(cv_bridge::Exception &e)
-        {
+        } catch (cv_bridge::Exception& e) {
             ROS_ERROR("\n\n\ncv_bridge exeception: %s\n\n\n", e.what());
         }
 
@@ -85,57 +87,46 @@ public:
     void sync_process()
     {
         std::cout << "\nStarting the measurements reader thread!\n";
-        
-        while( !pslam_->bexit_required_ )
-        {
-            if( pslam_->pslamstate_->stereo_ )
-            {
+
+        while (!pslam_->bexit_required_) {
+            if (pslam_->pslamstate_->stereo_) {
                 cv::Mat image0, image1;
 
                 std::lock_guard<std::mutex> lock(img_mutex);
 
-                if (!img0_buf.empty() && !img1_buf.empty())
-                {
+                if (!img0_buf.empty() && !img1_buf.empty()) {
                     double time0 = img0_buf.front()->header.stamp.toSec();
                     double time1 = img1_buf.front()->header.stamp.toSec();
 
                     // sync tolerance
-                    if(time0 < time1 - 0.015)
-                    {
+                    if (time0 < time1 - 0.015) {
                         img0_buf.pop();
                         std::cout << "\n Throw img0 -- Sync error : " << (time0 - time1) << "\n";
-                    }
-                    else if(time0 > time1 + 0.015)
-                    {
+                    } else if (time0 > time1 + 0.015) {
                         img1_buf.pop();
                         std::cout << "\n Throw img1 -- Sync error : " << (time0 - time1) << "\n";
-                    }
-                    else
-                    {
+                    } else {
                         image0 = getGrayImageFromMsg(img0_buf.front());
                         image1 = getGrayImageFromMsg(img1_buf.front());
                         img0_buf.pop();
                         img1_buf.pop();
 
-                        if( !image0.empty() && !image1.empty() ) {
+                        if (!image0.empty() && !image1.empty()) {
                             pslam_->addNewStereoImages(time0, image0, image1);
                         }
                     }
                 }
-            } 
-            else if( pslam_->pslamstate_->mono_ ) 
-            {
+            } else if (pslam_->pslamstate_->mono_) {
                 cv::Mat image0;
 
                 std::lock_guard<std::mutex> lock(img_mutex);
 
-                if ( !img0_buf.empty() )
-                {
+                if (!img0_buf.empty()) {
                     double time = img0_buf.front()->header.stamp.toSec();
                     image0 = getGrayImageFromMsg(img0_buf.front());
                     img0_buf.pop();
 
-                    if( !image0.empty()) {
+                    if (!image0.empty()) {
                         pslam_->addNewMonoImage(time, image0);
                     }
                 }
@@ -151,20 +142,57 @@ public:
     std::queue<sensor_msgs::ImageConstPtr> img0_buf;
     std::queue<sensor_msgs::ImageConstPtr> img1_buf;
     std::mutex img_mutex;
-    
-    SlamManager *pslam_;
+
+    SlamManager* pslam_;
 };
 
+// read images from folder and make sure they are sorted by filenames
+bool read_images_from_folder(std::string folder, float fps, std::vector<std::string>& filenames, std::vector<float>& timestamps)
+{
+    if (!std::experimental::filesystem::exists(folder))
+        return false;
+    std::vector<std::string> vimage_path;
+    for (const auto& entry : std::experimental::filesystem::directory_iterator(folder)) {
+        vimage_path.push_back(entry.path().string());
+    }
 
+    std::vector<std::string> vimage_extension(vimage_path.size());
+    std::vector<std::string> vimg_name, vimg_name_sorted;
+    std::vector<int> vimg_name_int;
+    for (size_t j = 0; j < vimage_path.size(); j++) {
+        std::string image_path = std::string(vimage_path[j].c_str());
+        int loc1 = image_path.find_last_of("\\/") + 1;
+        int loc2 = image_path.find_last_of(".");
+        std::string image_name = image_path.substr(loc1, loc2 - loc1);
+        std::string image_ext = image_path.substr(loc2 + 1, image_path.size());
+        vimg_name.push_back(image_name);
+        vimg_name_int.push_back(std::stoi(image_name));
+        vimage_extension[j] = image_ext;
+    }
+    std::vector<std::size_t> index(vimg_name.size());
+    std::iota(index.begin(), index.end(), 0);
+    std::sort(index.begin(), index.end(), [&](size_t a, size_t b) { return vimg_name_int[a] < vimg_name_int[b]; });
+
+    for (auto i : index) {
+        vimg_name_sorted.push_back(vimg_name[i]);
+    }
+    filenames.resize(vimg_name_sorted.size());
+    timestamps.resize(vimg_name_sorted.size());
+
+    for (size_t i = 0; i < vimg_name_sorted.size(); i++) {
+        filenames[i] = folder + "/" + vimg_name_sorted[i] + "." + vimage_extension[i];
+        timestamps[i] = (float)i / fps;
+    }
+    return true;
+}
 int main(int argc, char** argv)
 {
     // Init the node
     ros::init(argc, argv, "ov2slam_node");
 
-    if(argc < 2)
-    {
-       std::cout << "\nUsage: rosrun ov2slam ov2slam_node parameters_files/params.yaml\n";
-       return 1;
+    if (argc < 2) {
+        std::cout << "\nUsage: rosrun ov2slam ov2slam_node parameters_files/params.yaml\n";
+        return 1;
     }
 
     std::cout << "\nLaunching OV²SLAM...\n\n";
@@ -177,46 +205,80 @@ int main(int argc, char** argv)
     std::cout << "\nLoading parameters file : " << parameters_file << "...\n";
 
     const cv::FileStorage fsSettings(parameters_file.c_str(), cv::FileStorage::READ);
-    if(!fsSettings.isOpened()) {
-       std::cout << "Failed to open settings file...";
-       return 1;
+    if (!fsSettings.isOpened()) {
+        std::cout << "Failed to open settings file...";
+        return 1;
     } else {
         std::cout << "\nParameters file loaded...\n";
     }
 
     std::shared_ptr<SlamParams> pparams;
-    pparams.reset( new SlamParams(fsSettings) );
+    pparams.reset(new SlamParams(fsSettings));
 
     // Create the ROS Visualizer
     std::shared_ptr<RosVisualizer> prosviz;
-    prosviz.reset( new RosVisualizer(nh) );
+    prosviz.reset(new RosVisualizer(nh));
 
     // Setting up the SLAM Manager
     SlamManager slam(pparams, prosviz);
 
-    // Start the SLAM thread
-    std::thread slamthread(&SlamManager::run, &slam);
+    if (pparams->bread_images_from_folder_) {
+        std::vector<std::string> lfilenames, rfilenames;
+        std::vector<float> timestamps;
 
-    // Create the Bag file reader & callback functions
-    SensorsGrabber sb(&slam);
+        if (!read_images_from_folder(fsSettings["Camera.topic_left"], fsSettings["fps"], lfilenames, timestamps)) {
+            std::cout << "Failed to open image folder...";
+            return 1;
+        }
+        if (pparams->stereo_) {
+            if (!read_images_from_folder(fsSettings["Camera.topic_right"], fsSettings["fps"], rfilenames, timestamps)) {
+                std::cout << "Failed to open image folder...";
+                return 1;
+            }
+        }
+        slam.setFilenamesTimestamps(lfilenames, rfilenames, timestamps);
 
-    // Create callbacks according to the topics set in the parameters file
-    ros::Subscriber subleft = nh.subscribe(fsSettings["Camera.topic_left"], 2, &SensorsGrabber::subLeftImage, &sb);
-    ros::Subscriber subright = nh.subscribe(fsSettings["Camera.topic_right"], 2, &SensorsGrabber::subRightImage, &sb);
+        // Start the SLAM thread
+        std::thread slamthread(&SlamManager::run, &slam);
 
-    // Start a thread for providing new measurements to the SLAM
-    std::thread sync_thread(&SensorsGrabber::sync_process, &sb);
+        // ROS Spin
+        ros::spin();
 
-    // ROS Spin
-    ros::spin();
+        // Request Slam Manager thread to exit
+        slam.bexit_required_ = true;
 
-    // Request Slam Manager thread to exit
-    slam.bexit_required_ = true;
+        // Waiting end of SLAM Manager
+        while (slam.bis_on_) {
+            std::chrono::seconds dura(1);
+            std::this_thread::sleep_for(dura);
+        }
+    }
 
-    // Waiting end of SLAM Manager
-    while( slam.bis_on_ ) {
-        std::chrono::seconds dura(1);
-        std::this_thread::sleep_for(dura);
+    if (!pparams->bread_images_from_folder_) {
+        // Start the SLAM thread
+        std::thread slamthread(&SlamManager::run, &slam);
+
+        // Create the Bag file reader & callback functions
+        SensorsGrabber sb(&slam);
+
+        // Create callbacks according to the topics set in the parameters file
+        ros::Subscriber subleft = nh.subscribe(fsSettings["Camera.topic_left"], 2, &SensorsGrabber::subLeftImage, &sb);
+        ros::Subscriber subright = nh.subscribe(fsSettings["Camera.topic_right"], 2, &SensorsGrabber::subRightImage, &sb);
+
+        // Start a thread for providing new measurements to the SLAM
+        std::thread sync_thread(&SensorsGrabber::sync_process, &sb);
+
+        // ROS Spin
+        ros::spin();
+
+        // Request Slam Manager thread to exit
+        slam.bexit_required_ = true;
+
+        // Waiting end of SLAM Manager
+        while (slam.bis_on_) {
+            std::chrono::seconds dura(1);
+            std::this_thread::sleep_for(dura);
+        }
     }
 
     return 0;

--- a/src/slam_params.cpp
+++ b/src/slam_params.cpp
@@ -26,15 +26,18 @@
 
 #include "slam_params.hpp"
 
-SlamParams::SlamParams(const cv::FileStorage &fsSettings) {
+SlamParams::SlamParams(const cv::FileStorage& fsSettings)
+{
 
     std::cout << "\nSLAM Parameters are being setup...\n";
 
     // READ THE SETTINGS
-    debug_ = static_cast<int>(fsSettings["debug"]);;
-    log_timings_ = static_cast<int>(fsSettings["log_timings"]);;
+    debug_ = static_cast<int>(fsSettings["debug"]);
+    ;
+    log_timings_ = static_cast<int>(fsSettings["log_timings"]);
+    ;
 
-    mono_ =  static_cast<int>(fsSettings["mono"]);
+    mono_ = static_cast<int>(fsSettings["mono"]);
     stereo_ = static_cast<int>(fsSettings["stereo"]);
 
     bforce_realtime_ = static_cast<int>(fsSettings["force_realtime"]);
@@ -58,7 +61,7 @@ SlamParams::SlamParams(const cv::FileStorage &fsSettings) {
     p1l_ = fsSettings["Camera.p1l"];
     p2l_ = fsSettings["Camera.p2l"];
 
-    if( stereo_ ) {
+    if (stereo_) {
         cam_right_topic_.assign(fsSettings["Camera.topic_right"]);
         cam_right_model_.assign(fsSettings["Camera.model_right"]);
 
@@ -81,8 +84,8 @@ SlamParams::SlamParams(const cv::FileStorage &fsSettings) {
         fsSettings["body_T_cam0"] >> cvTbc0;
         fsSettings["body_T_cam1"] >> cvTbc1;
 
-        cv::cv2eigen(cvTbc0,Tbc0);
-        cv::cv2eigen(cvTbc1,Tbc1);
+        cv::cv2eigen(cvTbc0, Tbc0);
+        cv::cv2eigen(cvTbc1, Tbc1);
 
         T_left_right_ = Sophus::SE3d(Tbc0.inverse() * Tbc1);
     }
@@ -103,8 +106,8 @@ SlamParams::SlamParams(const cv::FileStorage &fsSettings) {
     dmaxquality_ = fsSettings["dmaxquality"];
 
     nmaxdist_ = fsSettings["nmaxdist"];
-    float nbwcells = ceil( (float)img_left_w_ / nmaxdist_ );
-    float nbhcells = ceil( (float)img_left_h_ / nmaxdist_ );
+    float nbwcells = ceil((float)img_left_w_ / nmaxdist_);
+    float nbhcells = ceil((float)img_left_h_ / nmaxdist_);
     nbmaxkps_ = nbwcells * nbhcells;
 
     use_clahe_ = static_cast<int>(fsSettings["use_clahe"]);
@@ -114,7 +117,7 @@ SlamParams::SlamParams(const cv::FileStorage &fsSettings) {
     klt_use_prior_ = static_cast<int>(fsSettings["klt_use_prior"]);
 
     btrack_keyframetoframe_ = static_cast<int>(fsSettings["btrack_keyframetoframe"]);
-    
+
     nklt_win_size_ = fsSettings["nklt_win_size"];
     nklt_pyr_lvl_ = fsSettings["nklt_pyr_lvl"];
 
@@ -124,7 +127,6 @@ SlamParams::SlamParams(const cv::FileStorage &fsSettings) {
     nmax_iter_ = fsSettings["nmax_iter"];
     fmax_px_precision_ = fsSettings["fmax_px_precision"];
 
-    
     nklt_err_ = fsSettings["nklt_err"];
 
     // Matching th.
@@ -158,13 +160,19 @@ SlamParams::SlamParams(const cv::FileStorage &fsSettings) {
     nmin_covscore_ = fsSettings["nmin_covscore"];
 
     // Map Filtering parameters
-    fkf_filtering_ratio_ = fsSettings["fkf_filtering_ratio"]; 
+    fkf_filtering_ratio_ = fsSettings["fkf_filtering_ratio"];
 
     // Apply Full BA?
     do_full_ba_ = static_cast<int>(fsSettings["do_full_ba"]);
+
+    bread_images_from_folder_ = static_cast<int>(fsSettings["read_images_from_folder"]);
+    if (bread_images_from_folder_) {
+        fps = fsSettings["fps"];
+    }
 }
 
-void SlamParams::reset() {
+void SlamParams::reset()
+{
     blocalba_is_on_ = false;
     blc_is_on_ = false;
     bvision_init_ = false;


### PR DESCRIPTION
Read an image sequence from a folder instead of subscribing to a rosbag.

To enable this option set the following in the parameter `YAML` file:

1. read_images_from_folder` to `1`.
2. `fps`  to the desired frame rate.
3. `Camera.topic_left` and `Camera.topic_right` (if stereo) to the path of the input folder(s).
4. `force_realtime` to `0`

This mode operates on the images sequentially and does not support skipping frames nor enforcing real-time.